### PR TITLE
Load schema from relative or system directory

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -210,14 +210,15 @@ const init = () => {};
 const enable = () => {
     // Initialize settings
     let schemaDir = Me.dir.get_child("schemas");
-    if (schemaDir.query_exists(null))
+    if (schemaDir.query_exists(null)) {
         let gschema = Gio.SettingsSchemaSource.new_from_directory(
             schemaDir.get_path(),
             Gio.SettingsSchemaSource.get_default(),
             false
         );
-    else
+    } else {
         let gschema = Gio.SettingsSchemaSource.get_default();
+    }
 
     settings = new Gio.Settings({
         settings_schema: gschema.lookup(

--- a/extension.js
+++ b/extension.js
@@ -209,11 +209,15 @@ const init = () => {};
 
 const enable = () => {
     // Initialize settings
-    let gschema = Gio.SettingsSchemaSource.new_from_directory(
-        Me.dir.get_child("schemas").get_path(),
-        Gio.SettingsSchemaSource.get_default(),
-        false
-    );
+    let schemaDir = Me.dir.get_child("schemas");
+    if (schemaDir.query_exists(null))
+        let gschema = Gio.SettingsSchemaSource.new_from_directory(
+            schemaDir.get_path(),
+            Gio.SettingsSchemaSource.get_default(),
+            false
+        );
+    else
+        let gschema = Gio.SettingsSchemaSource.get_default();
 
     settings = new Gio.Settings({
         settings_schema: gschema.lookup(

--- a/prefs.js
+++ b/prefs.js
@@ -14,11 +14,15 @@ const shellVersion = Number.parseInt(major);
 function init() {}
 
 function buildPrefsWidget() {
-    let gschema = Gio.SettingsSchemaSource.new_from_directory(
-        Me.dir.get_child("schemas").get_path(),
-        Gio.SettingsSchemaSource.get_default(),
-        false
-    );
+    let schemaDir = Me.dir.get_child("schemas");
+    if (schemaDir.query_exists(null))
+        let gschema = Gio.SettingsSchemaSource.new_from_directory(
+            schemaDir.get_path(),
+            Gio.SettingsSchemaSource.get_default(),
+            false
+        );
+    else
+        let gschema = Gio.SettingsSchemaSource.get_default();
 
     let settings = new Gio.Settings({
         settings_schema: gschema.lookup(

--- a/prefs.js
+++ b/prefs.js
@@ -14,15 +14,17 @@ const shellVersion = Number.parseInt(major);
 function init() {}
 
 function buildPrefsWidget() {
+    let gschema;
     let schemaDir = Me.dir.get_child("schemas");
-    if (schemaDir.query_exists(null))
-        let gschema = Gio.SettingsSchemaSource.new_from_directory(
+    if (schemaDir.query_exists(null)) {
+        gschema = Gio.SettingsSchemaSource.new_from_directory(
             schemaDir.get_path(),
             Gio.SettingsSchemaSource.get_default(),
             false
         );
-    else
-        let gschema = Gio.SettingsSchemaSource.get_default();
+    } else {
+        gschema = Gio.SettingsSchemaSource.get_default();
+    }
 
     let settings = new Gio.Settings({
         settings_schema: gschema.lookup(


### PR DESCRIPTION
Roughly adapted from [how emoji-selector does this](https://github.com/maoschanz/emoji-selector-for-gnome/blob/20/emoji-selector@maestroschan.fr/convenience.js#L77-L84).

Fixes #2