### PR TITLE
update to work with Gnome 42

### DIFF
--- a/dbus.js
+++ b/dbus.js
@@ -2,7 +2,7 @@
 
 const { Gio, GLib } = imports.gi;
 
-const ifacesXml = `
+var ifacesXml = `
     <node>
         <interface name="org.mpris.MediaPlayer2.Player">
             <method name="Next" />
@@ -37,7 +37,7 @@ const ifacesXml = `
 
 const nodeInfo = Gio.DBusNodeInfo.new_for_xml(ifacesXml);
 
-const createProxy = (ifaceName, busName, objectPath, flags = Gio.DBusProxyFlags.NONE) => {
+var createProxy = (ifaceName, busName, objectPath, flags = Gio.DBusProxyFlags.NONE) => {
     return new Promise((resolve, reject) => {
         let ifaceInfo = nodeInfo.interfaces.find((iface) => iface.name == ifaceName);
         if (ifaceInfo) {

--- a/extension.js
+++ b/extension.js
@@ -1,16 +1,18 @@
-const MediaControls = imports.misc.extensionUtils.getCurrentExtension().imports.widget.MediaControls;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Me = ExtensionUtils.getCurrentExtension();
+const MediaControls = Me.imports.widget.MediaControls;
 
 let extension;
 
-const init = () => {};
+function init() {};
 
-const enable = () => {
+function enable() {
     log("[MediaControls] Enabling");
     extension = new MediaControls();
     extension.enable();
 };
 
-const disable = () => {
+function disable() {
     log("[MediaControls] Disabling");
     extension.disable();
     extension = null;

--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
-    "description": "Show controls and information of the currently playing media in the panel.\n\n    - Highly customizable\n    - Support GNOME 3.36(beta) , 3.38, 40, 41\n    - Caches album art\n    - Control every element in the extension",
+    "description": "Show controls and information of the currently playing media in the panel.\n\n    - Highly customizable\n    - Support GNOME 3.36(beta) , 3.38, 40, 41, 42\n    - Caches album art\n    - Control every element in the extension",
     "name": "Media Controls",
     "settings-schema": "org.gnome.shell.extensions.mediacontrols",
-    "shell-version": ["3.36", "3.38", "40", "41"],
+    "shell-version": ["3.36", "3.38", "40", "41", "42"],
     "url": "https://github.com/cliffniff/media-controls",
     "uuid": "mediacontrols@cliffniff.github.com",
-    "version": 20
+    "version": 21
 }

--- a/player.js
+++ b/player.js
@@ -18,6 +18,7 @@ const urlRegexp = new RegExp(
 );
 
 let doubleClick = false;
+let clicked = false;
 
 let mouseActionTypes = {
     LEFT_CLICK: 0,
@@ -47,14 +48,12 @@ var Player = GObject.registerClass(
                         "org.mpris.MediaPlayer2.Player",
                         busName,
                         "/org/mpris/MediaPlayer2"
-                        // Gio.DBusProxyFlags.GET_INVALIDATED_PROPERTIES
                     );
 
                     this._otherProxy = createProxy(
                         "org.mpris.MediaPlayer2",
                         busName,
                         "/org/mpris/MediaPlayer2"
-                        // Gio.DBusProxyFlags.GET_INVALIDATED_PROPERTIES
                     );
 
                     [this._playerProxy, this._otherProxy] = await Promise.all([
@@ -106,10 +105,6 @@ var Player = GObject.registerClass(
             this.subContainerLabel = new St.BoxLayout({
                 style: "padding: 0px; margin: 0px;",
             });
-
-            // this.subContainerLabel.add_child(this.labelSeperatorStart);
-            // this.subContainerLabel.add_child(this.labelTitle);
-            // this.subContainerLabel.add_child(this.labelSeperatorEnd);
 
             this.containerButtonLabel = new St.Button({
                 style_class: "panel-button",
@@ -207,12 +202,7 @@ var Player = GObject.registerClass(
 
             this.containerControls = new St.BoxLayout();
 
-            // this.containerControls.add_child(this.buttonPrev);
-            // this.containerControls.add_child(this.buttonPlayPause);
-            // this.containerControls.add_child(this.buttonNext);
-
             // Sources dropdown button
-
             this.buttonMenu = new St.Button({
                 style_class: "panel-button",
                 style: "padding: 0px 3px; margin: 0px auto;",
@@ -224,12 +214,6 @@ var Player = GObject.registerClass(
             });
 
             this.dummyContainer = new St.BoxLayout();
-
-            // this.dummyContainer.add_child(this.buttonPlayer);
-            // this.dummyContainer.add_child(this.containerButtonLabel);
-            // this.dummyContainer.add_child(this.containerControls);
-            // this.dummyContainer.add_child(this.buttonMenu);
-
             this.add_style_class_name("no-vertical-spacing");
             this.add_child(this.dummyContainer);
 
@@ -743,10 +727,8 @@ var Player = GObject.registerClass(
         }
 
         _mouseActionButton(widget, event) {
-            let clickCount = event.get_click_count();
             let button = event.get_button();
-
-            if (clickCount === 1) {
+            if (!clicked) {
                 GLib.timeout_add(
                     GLib.PRIORITY_HIGH,
                     this._extension.clutterSettings.double_click_time,
@@ -763,17 +745,23 @@ var Player = GObject.registerClass(
                             }
                         }
                         doubleClick = false;
+                        clicked = false;
                         return GLib.SOURCE_REMOVE;
                     }
                 );
-            } else if (clickCount === 2) {
+            }
+            else {
                 doubleClick = true;
                 if (button === 1) {
                     this._mouseAction(mouseActionTypes.LEFT_DBL_CLICK);
                 } else if (button === 3) {
                     this._mouseAction(mouseActionTypes.RIGHT_DBL_CLICK);
                 }
+                clicked = false;
+                return;
             }
+
+            clicked = true;
         }
 
         _mouseActionScroll(widget, event) {

--- a/player.js
+++ b/player.js
@@ -30,7 +30,7 @@ let mouseActionTypes = {
     HOVER: 7,
 };
 
-const Player = GObject.registerClass(
+var Player = GObject.registerClass(
     class Player extends PanelMenu.Button {
         _init(busName, parent) {
             super._init(0.5, "Media Controls Track Information");

--- a/prefs.js
+++ b/prefs.js
@@ -202,7 +202,7 @@ const signalHandler = {
     },
 };
 
-const bindSettings = () => {
+function bindSettings() {
     settings.bind(
         "max-widget-width",
         builder.get_object("max-widget-width"),
@@ -284,7 +284,7 @@ const bindSettings = () => {
     );
 };
 
-const initWidgets = () => {
+function initWidgets() {
     // Init presets combobox
     presetSepChars.forEach((preset) => {
         widgetPreset.append(preset, preset);
@@ -424,11 +424,11 @@ const initWidgets = () => {
     })();
 };
 
-const init = () => {
+function init() {
     settings = ExtensionUtils.getSettings();
 };
 
-const buildPrefsWidget = () => {
+function buildPrefsWidget() {
     builder = new Gtk.Builder();
     if (shellVersion < 40) {
         builder.add_from_file(Me.dir.get_path() + "/prefs3.ui");

--- a/settings.js
+++ b/settings.js
@@ -1,5 +1,5 @@
 const ExtensionUtils = imports.misc.extensionUtils;
-class Settings {
+var Settings = class Settings {
     constructor(parent) {
         this._settings = ExtensionUtils.getSettings();
         this._extension = parent;

--- a/widget.js
+++ b/widget.js
@@ -19,7 +19,7 @@ const PopupMenu = imports.ui.popupMenu;
 
 const Mpris = imports.ui.mpris;
 
-const MediaControls = GObject.registerClass(
+var MediaControls = GObject.registerClass(
     class MediaControls extends PanelMenu.Button {
         _init() {
             super._init(0.5, "Media Controls Extension");


### PR DESCRIPTION
I only tested this on Gnome 42 so I don't know if it broke anything for "3.36", "3.38", "40", or "41"

FYI I also noticed that Seperators is misspelled everywhere (my IDE told me) it should be Separators